### PR TITLE
Add centos 7z bin path

### DIFF
--- a/src/Archive7z/Archive7z.php
+++ b/src/Archive7z/Archive7z.php
@@ -54,9 +54,12 @@ class Archive7z
      */
     protected $compressionLevel = 9;
     /**
-     * @var string
+     * @var array
      */
-    protected $cliLinux = '/usr/bin/7z';
+    protected $cliLinux = array(
+        '/usr/bin/7z',
+        '/usr/bin/7za' // CentOS 7 with package p7zip
+    );
     /**
      * @var string
      */
@@ -140,7 +143,11 @@ class Archive7z
         } elseif ($this->isOsWin()) {
             return $this->cliWindows;
         } else {
-            return $this->cliLinux;
+            foreach ($this->cliLinux as $cli) {
+                if (file_exists($cli)) {
+                    return $cli;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
В centos бинарник 7zip находится не там где у всех остальных Linux систем.
Преобразовал `$cliLinux` в массив. Теперь можно указывать много путей и эта либа будет более универсальной.