### PR TITLE
added "else" statement for "isOsWin()" checking

### DIFF
--- a/src/Archive7z.php
+++ b/src/Archive7z.php
@@ -139,10 +139,10 @@ class Archive7z
         $cliPath = null;
         if ($this->isOsBsd()) {
             $cliPath = $this->cliBsd;
-        } else
-            if ($this->isOsWin()) {
-            	$cliPath = $this->cliWindows;
-            }
+        } else if ($this->isOsWin()) {
+            $cliPath = $this->cliWindows;
+        }
+
         if (null === $cliPath) {
             $cliPath = $this->cliLinux;
         }

--- a/src/Archive7z.php
+++ b/src/Archive7z.php
@@ -139,10 +139,10 @@ class Archive7z
         $cliPath = null;
         if ($this->isOsBsd()) {
             $cliPath = $this->cliBsd;
-        }
-        if ($this->isOsWin()) {
-            $cliPath = $this->cliWindows;
-        }
+        } else
+            if ($this->isOsWin()) {
+            	$cliPath = $this->cliWindows;
+            }
         if (null === $cliPath) {
             $cliPath = $this->cliLinux;
         }


### PR DESCRIPTION
I found problem with "Archive7z::getAutoCli()" method in mac os system.
when "isOsBsd()" is runing, the "stripos" function finds 'Darwin' and when "isOsWin" is runing, 'win' is find to ('Darwin" = "Darwin" and "Darwin" = 'win"). So for the end "$cliPath" have path for windows not for mac os.
Must be "else" before "isOsWin()" checking.
Please confirm this changes. 