### PR TITLE
Update Archive7z.php

### DIFF
--- a/src/Archive7z.php
+++ b/src/Archive7z.php
@@ -370,7 +370,7 @@ class Archive7z
     }
 
     /**
-     * 7-zip >= 7.30 ( http://sourceforge.net/p/p7zip/discussion/383043/thread/f54fe89a/ )
+     * 7-zip >= 9.30 alpha ( http://sourceforge.net/p/p7zip/discussion/383043/thread/f54fe89a/ )
      *
      * @param string $pathSrc
      * @param string $pathDest


### PR DESCRIPTION
I think that's just a typo in versions, if I understand this right, because "rn" command has been added in 9.30 alpha (2012-10-26)  - https://www.7-zip.org/history.txt